### PR TITLE
.github/workflows: bump runners to 8vcpu and add Gradle sticky-disk cache

### DIFF
--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     name: Build app
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
 
     steps:
       - name: Clone repo
@@ -35,13 +35,21 @@ jobs:
           java-version: 17
           distribution: temurin
 
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+      - name: Mount Gradle home (sticky disk)
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-gradle-home
+          path: /home/runner/.gradle
 
       - name: Copy CI gradle.properties
         run: |
           mkdir -p ~/.gradle
           cp .github/runner-files/ci-gradle.properties ~/.gradle/gradle.properties
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: true
 
       - name: Build and test
         run: ./gradlew assembleStandardRelease testReleaseUnitTest testStandardReleaseUnitTest

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   build:
     name: Build app
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
 
     steps:
       - name: Clone repo

--- a/.github/workflows/build_check.yml
+++ b/.github/workflows/build_check.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Mount Gradle home (sticky disk)
         uses: useblacksmith/stickydisk@v1
         with:
-          key: ${{ github.repository }}-gradle-home
-          path: /home/runner/.gradle
+          key: ${{ github.repository }}-gradle-home-pr
+          path: ~/.gradle
 
       - name: Copy CI gradle.properties
         run: |

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -54,7 +54,12 @@ jobs:
         uses: useblacksmith/stickydisk@v1
         with:
           key: ${{ github.repository }}-gradle-home
-          path: /home/runner/.gradle
+          path: ~/.gradle
+
+      - name: Copy CI gradle.properties
+        run: |
+          mkdir -p ~/.gradle
+          cp .github/runner-files/ci-gradle.properties ~/.gradle/gradle.properties
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -63,11 +68,6 @@ jobs:
 
       - name: Setup CHANGELOG parser
         uses: taiki-e/install-action@parse-changelog
-
-      - name: Copy CI gradle.properties
-        run: |
-          mkdir -p ~/.gradle
-          cp .github/runner-files/ci-gradle.properties ~/.gradle/gradle.properties
 
       - name: Extract branch name
         id: branch_name

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   build:
     name: Build app
-    runs-on: blacksmith-16vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     environment: build
 
     steps:

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   build:
     name: Build app
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-16vcpu-ubuntu-2404
     environment: build
 
     steps:
@@ -50,8 +50,16 @@ jobs:
           java-version: 17
           distribution: temurin
 
+      - name: Mount Gradle home (sticky disk)
+        uses: useblacksmith/stickydisk@v1
+        with:
+          key: ${{ github.repository }}-gradle-home
+          path: /home/runner/.gradle
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-disabled: true
 
       - name: Setup CHANGELOG parser
         uses: taiki-e/install-action@parse-changelog


### PR DESCRIPTION
The Android Gradle build (assemble + R8 + unit tests) is CPU-heavy and benefits from more cores, and most of its wall-clock time is spent re-doing work that could come from a warm Gradle cache. This PR moves both `build_check.yml` (PR builds) and `build_push.yml` (release/nightly builds) to a larger Blacksmith Linux tier and replaces the GitHub Actions cache used by `gradle/actions/setup-gradle` with a Blacksmith Sticky Disk mounted at `~/.gradle`, which persists the full Gradle home (build cache, transformed AARs, KSP/KAPT outputs, daemon state, downloaded deps) across runs.

How it works:

- `runs-on:` is bumped from `blacksmith-4vcpu-ubuntu-2404` to `blacksmith-8vcpu-ubuntu-2404`. 8 vCPU is the cost/perf sweet spot for an Android Gradle build on the free plan: it gives a clear speedup over 4 vCPU on Kotlin compile, KAPT/KSP, R8, and parallel unit tests, while consuming free minutes at 4x the 2vCPU base rate (about 750 minutes/month) instead of 8x or 16x for the larger tiers. All Linux tiers (2/4/8/16/32) are available on the free plan; they consume the free-minute pool proportionally to vCPU count, so larger tiers can be slotted in later if 8 vCPU isn't enough.
- A `useblacksmith/stickydisk@v1` step mounts a persistent ext4 volume keyed by repo at `/home/runner/.gradle` before any Gradle work runs. The existing `Copy CI gradle.properties` step still writes into `~/.gradle` after the mount so the file lands on the sticky disk. `gradle/actions/setup-gradle` is kept (it still configures the Gradle wrapper and daemon) but with `cache-disabled: true` so it stops uploading and downloading the Gradle home through the GitHub Actions cache, which would otherwise duplicate the sticky-disk cache and slow the run down.

Both workflows share a single sticky-disk key (`${{ github.repository }}-gradle-home`) so PR and master/nightly builds warm the same cache. The first run after merge will be a cache miss and roughly the same speed as today; subsequent runs should see the largest wins on incremental Kotlin compile, KSP/KAPT, and R8. Behavior of the build and release steps themselves is unchanged.